### PR TITLE
Convert id to sting before querying

### DIFF
--- a/lib/resource_tools.rb
+++ b/lib/resource_tools.rb
@@ -18,7 +18,9 @@ module ResourceTools
     # we're probably not capturing all of the right messages.
     before_save :remember_if_we_are_a_new_record
 
-    scope :for_lims,  lambda { |lims| where(:id_lims=>lims) }
+    # IDs can be alphanumerics, so the column is not set to integer. While MySQL is smart enough to handle the conversion, it
+    # slows down the queries significantly (~400ms vs 2). Ruby handles the conversion much more quickly.
+    scope :for_lims,  lambda { |lims| where(:id_lims=>lims.to_s) }
     scope :with_uuid, lambda { |uuid| where(:"uuid_#{base.name.underscore}_lims"=>uuid)}
     scope :with_id,   lambda { |id|   where(:"id_#{base.name.underscore}_lims"=>id) }
   end


### PR DESCRIPTION
We store id as an alphanumeric as some lims use non integer identifiers.
However, Sequencescape currently generates messages with integer ids
as expected by the existing warehouse. While MySQl still returns the
correct records, it suffers a significant performance hit and we
can eliminate this by coercing our id before hand.
