### PR TITLE
Switch contains/contaminated_human_dna to bools

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -8,11 +8,18 @@ class Study < ActiveRecord::Base
   has_role(:lab_manager)
 
   json do
+
+    store_as_boolean(
+      :contains_human_dna,
+      :contaminated_human_dna
+    )
+
     ignore(
       :projects,
       :commercially_available,
       :samples
     )
+
     translate(
       :id                => :id_study_lims,
       :uuid              => :uuid_study_lims,

--- a/db/migrate/20150401145741_prepare_study_columns_for_migration_to_boolean.rb
+++ b/db/migrate/20150401145741_prepare_study_columns_for_migration_to_boolean.rb
@@ -1,0 +1,28 @@
+class PrepareStudyColumnsForMigrationToBoolean < ActiveRecord::Migration
+  def up
+    ActiveRecord::Base.transaction do
+      fields_to_convert.each do |field|
+        say "Updating #{field}..."
+        Study.where(field => 'Yes').update_all(field=>1)
+        Study.where(field => 'No').update_all(field=>0)
+      end
+    end
+  end
+
+  def down
+    ActiveRecord::Base.transaction do
+      fields_to_convert.each do |field|
+        say "Reverting #{field}..."
+        Study.where(field => '1').update_all(field=>'Yes')
+        Study.where(field => '0').update_all(field=>'No')
+      end
+    end
+  end
+
+  def fields_to_convert
+    [
+      :contains_human_dna,
+      :contaminated_human_dna
+    ]
+  end
+end

--- a/db/migrate/20150401150636_convert_study_contains_human_dna_and_contaminated_human_dna_to_boolean.rb
+++ b/db/migrate/20150401150636_convert_study_contains_human_dna_and_contaminated_human_dna_to_boolean.rb
@@ -1,0 +1,15 @@
+class ConvertStudyContainsHumanDnaAndContaminatedHumanDnaToBoolean < ActiveRecord::Migration
+  def up
+    change_table :study do |t|
+      t.change :contains_human_dna,     :boolean, comment:'Lane may contain human DNA'
+      t.change :contaminated_human_dna, :boolean, comment:'Human DNA in the lane is a contaminant and should be removed'
+    end
+  end
+
+  def down
+    change_table :study do |t|
+      t.change :contains_human_dna,     :string
+      t.change :contaminated_human_dna, :string
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -182,8 +182,8 @@ CREATE TABLE `study` (
   `abbreviation` varchar(255) DEFAULT NULL,
   `accession_number` varchar(50) DEFAULT NULL,
   `description` text,
-  `contains_human_dna` varchar(255) DEFAULT NULL,
-  `contaminated_human_dna` varchar(255) DEFAULT NULL,
+  `contains_human_dna` tinyint(1) DEFAULT NULL COMMENT 'Lane may contain human DNA',
+  `contaminated_human_dna` tinyint(1) DEFAULT NULL COMMENT 'Human DNA in the lane is a contaminant and should be removed',
   `data_release_strategy` varchar(255) DEFAULT NULL,
   `data_release_sort_of_study` varchar(255) DEFAULT NULL,
   `ena_project_id` varchar(255) DEFAULT NULL,
@@ -237,7 +237,7 @@ CREATE TABLE `study_users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2015-04-01 14:40:57
+-- Dump completed on 2015-04-01 16:11:24
 INSERT INTO schema_migrations (version) VALUES ('20141113110635');
 
 INSERT INTO schema_migrations (version) VALUES ('20141113130813');
@@ -253,4 +253,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150113134336');
 INSERT INTO schema_migrations (version) VALUES ('20150113142419');
 
 INSERT INTO schema_migrations (version) VALUES ('20150401132814');
+
+INSERT INTO schema_migrations (version) VALUES ('20150401145741');
+
+INSERT INTO schema_migrations (version) VALUES ('20150401150636');
 

--- a/lib/resource_tools/core_extensions.rb
+++ b/lib/resource_tools/core_extensions.rb
@@ -38,6 +38,14 @@ module ResourceTools::CoreExtensions
       return false if value.nil?
       self == value.to_s
     end
+
+    def to_boolean_from_arguments
+      case
+      when ['true', 'yes'].include?(self.downcase) then true
+      when ['false', 'no'].include?(self.downcase) then false
+      else raise "Cannot convert #{self.inspect} to a boolean safely!"
+      end
+    end
   end
 
   module Numeric
@@ -64,12 +72,20 @@ module ResourceTools::CoreExtensions
       yield(nil)
     end
   end
+
+  module SelfReferencingBoolean
+    def to_boolean_from_arguments
+      self
+    end
+  end
 end
 
 # Extend the core classes with the behaviour we need
-class Array    ; include ResourceTools::CoreExtensions::Array    ; end
-class Hash     ; include ResourceTools::CoreExtensions::Hash     ; end
-class Object   ; include ResourceTools::CoreExtensions::Object   ; end
-class String   ; include ResourceTools::CoreExtensions::String   ; end
-class Numeric  ; include ResourceTools::CoreExtensions::Numeric  ; end
-class NilClass ; include ResourceTools::CoreExtensions::NilClass ; end
+class Array      ; include ResourceTools::CoreExtensions::Array    ; end
+class Hash       ; include ResourceTools::CoreExtensions::Hash     ; end
+class Object     ; include ResourceTools::CoreExtensions::Object   ; end
+class String     ; include ResourceTools::CoreExtensions::String   ; end
+class Numeric    ; include ResourceTools::CoreExtensions::Numeric  ; end
+class NilClass   ; include ResourceTools::CoreExtensions::NilClass; include ResourceTools::CoreExtensions::SelfReferencingBoolean ; end
+class TrueClass  ; include ResourceTools::CoreExtensions::SelfReferencingBoolean ; end
+class FalseClass ; include ResourceTools::CoreExtensions::SelfReferencingBoolean ; end

--- a/lib/resource_tools/json.rb
+++ b/lib/resource_tools/json.rb
@@ -20,6 +20,9 @@ module ResourceTools::Json
     class_attribute :ignoreable
     self.ignoreable = []
 
+    class_attribute :stored_as_boolean
+    self.stored_as_boolean = []
+
     class_attribute :nested_models
     self.nested_models = {}
 
@@ -45,6 +48,10 @@ module ResourceTools::Json
 
       def ignore(*attributes)
         self.ignoreable += attributes.map(&:to_s)
+      end
+
+      def store_as_boolean(*attributes)
+        self.stored_as_boolean += attributes.map(&:to_s)
       end
 
       # JSON attributes can be translated into the attributes on the way in.
@@ -95,8 +102,16 @@ module ResourceTools::Json
       self.class.custom_values.each do |k,block|
         self[k] = self.instance_eval(&block)
       end if self.class.custom_values.present?
+      convert_booleans
       delete_if { |k,_| ignoreable.include?(k) }
     end
+
+    def convert_booleans
+      self.stored_as_boolean.each do |key|
+        self[key] = self[key].to_boolean_from_arguments if self.has_key?(key)
+      end
+    end
+    private :convert_booleans
 
     def deleted?
       deleted_at.present?

--- a/script/dump_deadletters
+++ b/script/dump_deadletters
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'thor'
 require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path('../../lib/resource_tools/core_extensions', __FILE__)
 
 class NilClass
   def pretty_dump_to(io)
@@ -21,34 +22,18 @@ class Fixnum
 end
 
 class TrueClass
-  def to_boolean_from_arguments
-    self
-  end
-
   def pretty_dump_to(io)
     io.write('true')
   end
 end
 
 class FalseClass
-  def to_boolean_from_arguments
-    self
-  end
-
   def pretty_dump_to(io)
     io.write('false')
   end
 end
 
 class String
-  def to_boolean_from_arguments
-    case
-    when ['true', 'yes'].include?(self.downcase) then true
-    when ['false', 'no'].include?(self.downcase) then false
-    else raise "Cannot convert #{self.inspect} to a boolean safely!"
-    end
-  end
-
   def pretty_dump_to(io)
     io.write(self.inspect)
   end

--- a/spec/models/study_spec.rb
+++ b/spec/models/study_spec.rb
@@ -17,6 +17,11 @@ describe Study do
     let(:additional_roles) { [ :data_access_contact, :slf_manager, :lab_manager ] }
   end
 
+  it_behaves_like 'store as boolean', {
+    'contains_human_dna'     => 'Yes',
+    'contaminated_human_dna' => 'No'
+  }
+
   let(:json) do
     {
       "uuid" => "11111111-2222-3333-4444-555555555555",
@@ -33,8 +38,8 @@ describe Study do
       "description" => "description",
       "updated_at" => "2012-03-11 10:20:08",
       "created_at" => "2012-03-11 10:20:08",
-      "contains_human_dna" => "contains human dna",
-      "contaminated_human_dna" => "contaminated human dna",
+      "contains_human_dna" => true,
+      "contaminated_human_dna" => true,
       "data_release_strategy" => "data release strategy",
       "data_release_sort_of_study" => "data release sort of study",
       "data_release_timing" => "data release timing",

--- a/spec/resource_tools/core_extensions_spec.rb
+++ b/spec/resource_tools/core_extensions_spec.rb
@@ -12,6 +12,10 @@ module ResourceTools::CoreExtensions
       it 'yields value' do
         nil.latest('value', &callback.method(:call))
       end
+
+      it 'should remain unchanged' do
+        expect(nil.to_boolean_from_arguments).to be nil
+      end
     end
   end
 
@@ -46,6 +50,26 @@ module ResourceTools::CoreExtensions
     end
   end
 
+  describe TrueClass do
+
+    subject { true }
+
+    it 'should remain unchanged' do
+      expect(subject.to_boolean_from_arguments).to be true
+    end
+
+  end
+
+  describe FalseClass do
+
+    subject { false }
+
+    it 'should remain unchanged' do
+      expect(subject.to_boolean_from_arguments).to be false
+    end
+
+  end
+
   describe Object do
     subject { ::Object.new }
 
@@ -61,9 +85,11 @@ module ResourceTools::CoreExtensions
   end
 
   describe String do
-    subject { 'value' }
 
     context '#within_acceptable_bounds?' do
+
+      subject { 'value' }
+
       it 'returns false if the value is nil' do
         expect(subject.within_acceptable_bounds?(nil)).to be false
       end
@@ -83,6 +109,29 @@ module ResourceTools::CoreExtensions
           end
         end
         expect(subject.within_acceptable_bounds?(object)).to be true
+      end
+    end
+
+
+    context '#to_boolean_from_arguments' do
+
+      context 'when it is Yes' do
+        subject { 'Yes' }
+        it 'returns true' do
+          expect(subject.to_boolean_from_arguments).to be true
+        end
+      end
+      context 'when it is No' do
+        subject { 'No' }
+        it 'returns false' do
+          expect(subject.to_boolean_from_arguments).to be false
+        end
+      end
+      context 'when it is unknown' do
+        subject { 'Unknown' }
+        it 'raises an exception' do
+          expect { subject.to_boolean_from_arguments }.to raise_error RuntimeError, 'Cannot convert "Unknown" to a boolean safely!'
+        end
       end
     end
   end

--- a/spec/support/it_behaves_like_maps_json_fields.rb
+++ b/spec/support/it_behaves_like_maps_json_fields.rb
@@ -23,3 +23,16 @@ shared_examples_for 'ignores JSON fields' do |ignored_attributes|
     end
   end
 end
+
+shared_examples_for 'store as boolean' do |boolean_fields|
+  let!(:json_handler) { described_class.send(:json) }
+
+  context "Handler" do
+    conversion = { 'Yes'=>true, 'No'=>false }
+    boolean_fields.each do |field,value|
+      it "converts #{field} to #{conversion[value]}" do
+        expect(json_handler.new(json.merge(field => value)).fetch(field)).to eq(conversion[value])
+      end
+    end
+  end
+end


### PR DESCRIPTION
The columns contains_human_dna and
contaminated_human_dna were effectively booleans,
yet Sequencescape was broadcasting 'Yes' and 'No'.
This was inconsistent with other columns in the
same table, but updating Sequencescape will have
knock on effects.

- Two migrations to convert data, and update the column

- Add store_as_boolean for string conversion

store_as_boolean ensures that 'Yes' and 'No' are
converted to true and false booleans respectively.