### PR TITLE
Add indexes to sanger_sample_id and supplier_name columns

### DIFF
--- a/db/migrate/20201112100120_add_index_to_sample_supplier_name_and_sanger_sample_id.rb
+++ b/db/migrate/20201112100120_add_index_to_sample_supplier_name_and_sanger_sample_id.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Addresses Issue#139
+# Indexes added to improved query performance for end users
+class AddIndexToSampleSupplierNameAndSangerSampleId < ActiveRecord::Migration[6.0]
+  def change
+    change_table :sample, bulk: true do |t|
+      t.index :supplier_name
+      t.index :sanger_sample_id
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -314,7 +314,9 @@ CREATE TABLE `sample` (
   UNIQUE KEY `index_sample_on_id_sample_lims_and_id_lims` (`id_sample_lims`,`id_lims`),
   UNIQUE KEY `sample_uuid_sample_lims_index` (`uuid_sample_lims`),
   KEY `sample_accession_number_index` (`accession_number`),
-  KEY `sample_name_index` (`name`)
+  KEY `sample_name_index` (`name`),
+  KEY `index_sample_on_supplier_name` (`supplier_name`),
+  KEY `index_sample_on_sanger_sample_id` (`sanger_sample_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=49650 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `samples_extraction_activity`;
@@ -514,6 +516,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200929142921'),
 ('20201028091922'),
 ('20201029150039'),
-('20201103161806');
+('20201103161806'),
+('20201112100120');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -166,7 +166,7 @@ CREATE TABLE `lighthouse_sample` (
   `ch4_result` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'Result for channel 4',
   `ch4_cq` decimal(11,8) DEFAULT NULL COMMENT 'Cq value for channel 4',
   `filtered_positive` tinyint(1) DEFAULT NULL COMMENT 'Filtered positive result value',
-  `filtered_positive_version` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'Filtered positive version',
+  `filtered_positive_version` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'Filtered positive version',
   `filtered_positive_timestamp` datetime DEFAULT NULL COMMENT 'Filtered positive timestamp',
   `created_at` datetime DEFAULT NULL COMMENT 'When this record was inserted',
   `updated_at` datetime DEFAULT NULL COMMENT 'When this record was last updated',


### PR DESCRIPTION
As requested by David H:
>We’re helping Keiran R to improve the performance of a couple of queries which he is running on the Multi-LIMS warehouse.  Experimenting with a clone of the mlwarehoue database, we’ve found that adding two indexes to the ‘sample’ table would help to turn a query that currently takes 90 seconds to one which will run in 0.1 second.

>Please could you add indexes on the ‘supplier_name’ and ‘sanger_sample_id’ columns.  This barely increases the total size of the indexes on this table, so it will have no adverse impact on other users, and may even help anyone who is running queries similar to Keiran’s.  Adding the indexes can be done at any time, since MySQL does not lock a table when a secondary index is created.  In any case, each index takes less than a minute to add.

Fixes #139
