### PR TITLE
DPL-040: Improve efficiency of migration

### DIFF
--- a/db/migrate/20210819162539_add_current_rna_id_to_lighthouse_sample.rb
+++ b/db/migrate/20210819162539_add_current_rna_id_to_lighthouse_sample.rb
@@ -11,11 +11,11 @@ class AddCurrentRnaIdToLighthouseSample < ActiveRecord::Migration[6.0]
 
     # Infer and populate historic values for is_current.
     execute %{
-      UPDATE lhs_short SET is_current = true
+      UPDATE lighthouse_sample SET is_current = true
       WHERE id IN (
         SELECT a.max_id FROM (
           SELECT rna_id, max(id) AS max_id
-            FROM lhs_short
+            FROM lighthouse_sample
             GROUP BY rna_id
         ) AS a
       );

--- a/db/migrate/20210819162539_add_current_rna_id_to_lighthouse_sample.rb
+++ b/db/migrate/20210819162539_add_current_rna_id_to_lighthouse_sample.rb
@@ -13,11 +13,11 @@ class AddCurrentRnaIdToLighthouseSample < ActiveRecord::Migration[6.0]
     execute %{
       UPDATE lighthouse_sample SET is_current = true
       WHERE id IN (
-        SELECT a.max_id FROM (
+        SELECT most_recent.max_id FROM (
           SELECT rna_id, max(id) AS max_id
             FROM lighthouse_sample
             GROUP BY rna_id
-        ) AS a
+        ) AS most_recent
       );
     }
 

--- a/db/migrate/20210819162539_add_current_rna_id_to_lighthouse_sample.rb
+++ b/db/migrate/20210819162539_add_current_rna_id_to_lighthouse_sample.rb
@@ -4,37 +4,30 @@
 # reconstructed values from existing data.
 class AddCurrentRnaIdToLighthouseSample < ActiveRecord::Migration[6.0]
   def self.up
-    # Add columns for boolean is_current and current RNA ID.
+    # Add column for boolean is_current.
     change_table :lighthouse_sample, bulk: true do |t|
       t.boolean :is_current, null: false, default: false, comment: 'Identifies if this sample has the most up to date information for the same rna_id'
-      t.index %i[is_current], unique: false # same uniqueness criteria as in MongoDB
+    end
 
+    # Infer and populate historic values for is_current.
+    execute %{
+      UPDATE lhs_short SET is_current = true
+      WHERE id IN (
+        SELECT a.max_id FROM (
+          SELECT rna_id, max(id) AS max_id
+            FROM lhs_short
+            GROUP BY rna_id
+        ) AS a
+      );
+    }
+
+    # Add a generated stored column to display the RNA ID if a row is the current entry.
+    change_table :lighthouse_sample, bulk: true do |t|
       # current_rna_id is a function of rna_id and is_current, so create it as a virtual column
       # This way no users of this table need to concern themselves with keeping this column in sync with the others
       t.virtual :current_rna_id, type: :string, as: 'if((is_current = 1),rna_id,NULL)', stored: true
       t.index %i[current_rna_id], unique: true # same uniqueness criteria as in MongoDB
     end
-
-    # Infer and populate historic values for is_current.
-    execute %{
-      UPDATE
-        lighthouse_sample AS lsample,
-        (
-          SELECT
-            temp_lsample.id,
-            IF(most_recent_samples.most_recent_id IS NULL, 0, 1) AS is_current
-          FROM lighthouse_sample AS temp_lsample
-          LEFT JOIN (
-            SELECT rna_id, max(id) AS most_recent_id
-            FROM lighthouse_sample
-            GROUP BY rna_id
-          ) AS most_recent_samples
-          ON temp_lsample.rna_id=most_recent_samples.rna_id
-            AND temp_lsample.id=most_recent_samples.most_recent_id
-        ) AS updated_data
-      SET lsample.is_current=updated_data.is_current
-      WHERE lsample.id=updated_data.id;
-    }
   end
 
   def self.down
@@ -44,9 +37,8 @@ class AddCurrentRnaIdToLighthouseSample < ActiveRecord::Migration[6.0]
       t.remove :current_rna_id
     end
 
-    # Drop index and column for is_current.
-    change_table :lighthouse_sample, bulk: true do |t|
-      t.remove_index %i[is_current]
+    # Drop column for is_current.
+    change_table :lighthouse_sample do |t|
       t.remove :is_current
     end
   end


### PR DESCRIPTION
Closes https://github.com/sanger/crawler/issues/361

The migration on UAT took over 12 hours to complete before.  This is an optimised migration that should take around 1 hour instead.  When we are ready to try this, I will backwards migrate the database on the current version, then install this version and migrate the database again to test performance.