### PR TITLE
Add pipeline_id_lims to pac_bio_run table

### DIFF
--- a/db/migrate/20211221170427_add_pipeline_id_lims_to_pac_bio_run_table.rb
+++ b/db/migrate/20211221170427_add_pipeline_id_lims_to_pac_bio_run_table.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# A column equivalent to library_type in the iseq flowcell tables is being added to pacbio
+class AddPipelineIdLimsToPacBioRunTable < ActiveRecord::Migration[6.0]
+  def change
+    change_table :pac_bio_run, bulk: true do |t|
+      t.string :pipeline_id_lims, null: true, default: nil, limit: 60, comment: 'LIMs-specific pipeline identifier that unambiguously defines library type'
+    end
+  end
+end

--- a/db/migrate/20211221170427_add_pipeline_id_lims_to_pac_bio_run_table.rb
+++ b/db/migrate/20211221170427_add_pipeline_id_lims_to_pac_bio_run_table.rb
@@ -4,7 +4,7 @@
 class AddPipelineIdLimsToPacBioRunTable < ActiveRecord::Migration[6.0]
   def change
     change_table :pac_bio_run, bulk: true do |t|
-      t.string :pipeline_id_lims, null: true, default: nil, limit: 60, comment: 'LIMs-specific pipeline identifier that unambiguously defines library type'
+      t.string :pipeline_id_lims, null: true, default: nil, limit: 60, comment: 'LIMS-specific pipeline identifier that unambiguously defines library type (eg. Sequel-v1, IsoSeq-v1)'
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_09_125417) do
+ActiveRecord::Schema.define(version: 2021_12_21_170427) do
 
   create_table "bmap_flowcell", primary_key: "id_bmap_flowcell_tmp", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "last_updated", null: false, comment: "Timestamp of last update"
@@ -207,6 +207,7 @@ ActiveRecord::Schema.define(version: 2021_11_09_125417) do
     t.integer "pac_bio_library_tube_legacy_id", comment: "Legacy library_id for backwards compatibility."
     t.datetime "library_created_at", comment: "Timestamp of library creation"
     t.string "pac_bio_run_name", comment: "Name of the run"
+    t.string "pipeline_id_lims", limit: 60, comment: "LIMs-specific pipeline identifier that unambiguously defines library type"
     t.index ["id_sample_tmp"], name: "fk_pac_bio_run_to_sample"
     t.index ["id_study_tmp"], name: "fk_pac_bio_run_to_study"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -207,7 +207,7 @@ ActiveRecord::Schema.define(version: 2021_12_21_170427) do
     t.integer "pac_bio_library_tube_legacy_id", comment: "Legacy library_id for backwards compatibility."
     t.datetime "library_created_at", comment: "Timestamp of library creation"
     t.string "pac_bio_run_name", comment: "Name of the run"
-    t.string "pipeline_id_lims", limit: 60, comment: "LIMs-specific pipeline identifier that unambiguously defines library type"
+    t.string "pipeline_id_lims", limit: 60, comment: "LIMS-specific pipeline identifier that unambiguously defines library type (eg. Sequel-v1, IsoSeq-v1)"
     t.index ["id_sample_tmp"], name: "fk_pac_bio_run_to_sample"
     t.index ["id_study_tmp"], name: "fk_pac_bio_run_to_study"
   end

--- a/spec/models/pac_bio_run_spec.rb
+++ b/spec/models/pac_bio_run_spec.rb
@@ -52,7 +52,8 @@ describe PacBioRun do
               'tag2_identifier' => '1',
               'tag2_sequence' => 'GTCA',
               'tag2_set_id_lims' => '2',
-              'tag2_set_name' => 'tag_set_2'
+              'tag2_set_name' => 'tag_set_2',
+              'pipeline_id_lims' => 'IsoSeq'
             },
             {
               'sample_uuid' => '000000-0000-0000-0000-0000000000',


### PR DESCRIPTION
Closes #285

Adds the pipeline_id_lims as a non-required field to the pac_bio_runs table.

Shoule be deployed before: https://github.com/sanger/traction-service/issues/639
