### PR TITLE
Add unique to labware_barcode column

### DIFF
--- a/db/migrate/20230605152453_create_labware_location.rb
+++ b/db/migrate/20230605152453_create_labware_location.rb
@@ -4,7 +4,7 @@
 class CreateLabwareLocation < ActiveRecord::Migration[7.0]
   def change
     create_table :labware_location do |t|
-      t.string :labware_barcode, unique: true, null: false, comment: 'Barcode on the stored labware'
+      t.string :labware_barcode, null: false, comment: 'Barcode on the stored labware'
       t.string :location_barcode, null: false, comment: 'Barcode associated with storage location'
       t.string :full_location_address, null: false, comment: 'Fully qualifed address of the nested location'
       t.integer :coordinate_position, null: true, comment: 'Coordinate position of labware in storage location'
@@ -16,6 +16,7 @@ class CreateLabwareLocation < ActiveRecord::Migration[7.0]
 
       t.timestamps
 
+      t.index :labware_barcode, unique: true
       t.index :location_barcode
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -119,6 +119,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_05_152453) do
     t.datetime "stored_at", null: false, comment: "Datetime the item was stored at this location"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["labware_barcode"], name: "index_labware_location_on_labware_barcode", unique: true
     t.index ["location_barcode"], name: "index_labware_location_on_location_barcode"
   end
 


### PR DESCRIPTION
Closes https://github.com/sanger/General-Backlog-Items/issues/221

Changes proposed in this pull request:

* Previous implementation did not make `labware_barcode` column unique. Adding an index in this way will make the column unique so data is not duplicated in the table.
