### PR TITLE
Update uniqueness on pac_bio_run table

### DIFF
--- a/db/migrate/20230704101316_update_unique_pacbio_entry_index.rb
+++ b/db/migrate/20230704101316_update_unique_pacbio_entry_index.rb
@@ -1,0 +1,9 @@
+class UpdateUniquePacbioEntryIndex < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :pac_bio_run, name: 'unique_pac_bio_entry'
+
+    add_index :pac_bio_run,
+              %i[id_lims id_pac_bio_run_lims well_label comparable_tag_identifier comparable_tag2_identifier plate_number],
+              unique: true, name: 'unique_pac_bio_entry'
+  end
+end

--- a/db/migrate/20230704101316_update_unique_pacbio_entry_index.rb
+++ b/db/migrate/20230704101316_update_unique_pacbio_entry_index.rb
@@ -1,9 +1,20 @@
+# frozen_string_literal: true
+
+# Updates uniqueness constraint to check on: lims, run, well, tag, tag2 and plate number
 class UpdateUniquePacbioEntryIndex < ActiveRecord::Migration[7.0]
-  def change
-    remove_index :pac_bio_run, name: 'unique_pac_bio_entry'
+  def self.up
+    remove_index :pac_bio_run, %i[id_lims id_pac_bio_run_lims well_label comparable_tag_identifier comparable_tag2_identifier]
 
     add_index :pac_bio_run,
               %i[id_lims id_pac_bio_run_lims well_label comparable_tag_identifier comparable_tag2_identifier plate_number],
+              unique: true, name: 'unique_pac_bio_entry'
+  end
+
+  def self.down
+    remove_index :pac_bio_run, %i[id_lims id_pac_bio_run_lims well_label comparable_tag_identifier comparable_tag2_identifier plate_number]
+
+    add_index :pac_bio_run,
+              %i[id_lims id_pac_bio_run_lims well_label comparable_tag_identifier comparable_tag2_identifier],
               unique: true, name: 'unique_pac_bio_entry'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_07_095528) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_04_101316) do
   create_table "bmap_flowcell", primary_key: "id_bmap_flowcell_tmp", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "last_updated", precision: nil, null: false, comment: "Timestamp of last update"
     t.datetime "recorded_at", precision: nil, null: false, comment: "Timestamp of warehouse update"
@@ -250,7 +250,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_07_095528) do
     t.virtual "comparable_tag2_identifier", type: :string, as: "ifnull(`tag2_identifier`,-(1))"
     t.integer "plate_number", comment: "The number of the plate that goes onto the sequencing machine. Necessary as an identifier for multi-plate support."
     t.string "pac_bio_library_tube_barcode", comment: "The barcode of the originating library tube"
-    t.index ["id_lims", "id_pac_bio_run_lims", "well_label", "comparable_tag_identifier", "comparable_tag2_identifier"], name: "unique_pac_bio_entry", unique: true
+    t.index ["id_lims", "id_pac_bio_run_lims", "well_label", "comparable_tag_identifier", "comparable_tag2_identifier", "plate_number"], name: "unique_pac_bio_entry", unique: true
     t.index ["id_sample_tmp"], name: "fk_pac_bio_run_to_sample"
     t.index ["id_study_tmp"], name: "fk_pac_bio_run_to_study"
   end


### PR DESCRIPTION
Required for https://github.com/sanger/traction-service/issues/992

Changes proposed in this pull request:

* Add `plate_number` to uniqueness constraint on `pac_bio_run` table, as there maybe two wells with the same position/ pool/ run etc, but on different plates 
