### PR TITLE
DPL-843 - Populate plate number for sequencescape pac_bio_run entries

### DIFF
--- a/lib/tasks/update_pac_bio_run_sequencescape_plate_numbers.rake
+++ b/lib/tasks/update_pac_bio_run_sequencescape_plate_numbers.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Updates all sequncescape pac bio runs to have the plate number 1
+
+namespace :pac_bio_run_table do
+  desc 'Update pac_bio_run_name plate_number column with the value 1 for sequencescape plates'
+
+  task update_pac_bio_run_sequencescape_plate_numbers: :environment do
+    PacBioRun.all.each do |run|
+      next if run.id_lims != 'SQSCP'
+
+      run.plate_number = 1
+      run.save!
+    end
+  end
+end

--- a/lib/tasks/update_pac_bio_run_sequencescape_plate_numbers.rake
+++ b/lib/tasks/update_pac_bio_run_sequencescape_plate_numbers.rake
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-# Updates all sequncescape pac bio runs to have the plate number 1
+# Updates all sequencescape pac_bio_run entries to have the plate number 1
 
 namespace :pac_bio_run_table do
-  desc 'Update pac_bio_run_name plate_number column with the value 1 for sequencescape plates'
+  desc 'Update pac_bio_run plate_number column with the value 1 for sequencescape plates'
 
   task update_pac_bio_run_sequencescape_plate_numbers: :environment do
     PacBioRun.all.each do |run|

--- a/lib/tasks/update_pac_bio_run_sequencescape_plate_numbers.rake
+++ b/lib/tasks/update_pac_bio_run_sequencescape_plate_numbers.rake
@@ -6,9 +6,7 @@ namespace :pac_bio_run_table do
   desc 'Update pac_bio_run plate_number column with the value 1 for sequencescape plates'
 
   task update_pac_bio_run_sequencescape_plate_numbers: :environment do
-    PacBioRun.all.each do |run|
-      next if run.id_lims != 'SQSCP'
-
+    PacBioRun.where(id_lims: 'SQSCP').each do |run|
       run.plate_number = 1
       run.save!
     end


### PR DESCRIPTION
Closes #526 

Changes proposed in this pull request:

- Added rake task to set the plate number to 1 for all pac_bio_run entries from sequencescape

`bundle exec rails pac_bio_run_table:update_pac_bio_run_sequencescape_plate_numbers`


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check version_  
