### PR TITLE
Rename aliquot table's lims_uuid column to aliquot_uuid

### DIFF
--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -7,12 +7,12 @@ class Aliquot < ApplicationRecord
   include SingularResourceTools
 
   def self.base_resource_key
-    'lims_uuid'
+    'aliquot_uuid'
   end
 
   json do
     translate(
-      uuid: :lims_uuid
+      uuid: :aliquot_uuid
     )
 
     ignore :created

--- a/db/migrate/20240723152109_rename_lims_uuid_colum_to_aliquot_uu_id_in_aliquot_table.rb
+++ b/db/migrate/20240723152109_rename_lims_uuid_colum_to_aliquot_uu_id_in_aliquot_table.rb
@@ -1,0 +1,9 @@
+class RenameLimsUuidColumToAliquotUuIdInAliquotTable < ActiveRecord::Migration[7.0]
+  def up
+    rename_column :aliquot, :lims_uuid, :aliquot_uuid
+  end
+
+  def down
+    rename_column :aliquot, :aliquot_uuid, :lims_uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_08_081135) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_23_152109) do
   create_table "aliquot", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "id_lims", null: false, comment: "The LIMS system that the aliquot was created in"
-    t.string "lims_uuid", null: false, comment: "The UUID of the aliquot in the LIMS system"
+    t.string "aliquot_uuid", null: false, comment: "The UUID of the aliquot in the LIMS system"
     t.string "aliquot_type", null: false, comment: "The type of the aliquot"
     t.string "source_type", null: false, comment: "The type of the source of the aliquot"
     t.string "source_barcode", null: false, comment: "The barcode of the source of the aliquot"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -86,7 +86,7 @@ FactoryBot.define do
   factory :aliquot do
     sequence(:id) { |n| n }
     id_lims { 'example' }
-    lims_uuid { '000000-0000-0000-0000-0000000002' }
+    aliquot_uuid { '000000-0000-0000-0000-0000000002' }
     aliquot_type { 'derivative' }
     source_type { 'library' }
     source_barcode { 'PR-rna-00000001_H12' }

--- a/spec/models/aliquot_spec.rb
+++ b/spec/models/aliquot_spec.rb
@@ -12,7 +12,7 @@ describe Aliquot do
         'volume' => 5.43,
         'concentration' => 2.34,
         'insert_size' => 100,
-        'lims_uuid' => '000000-0000-0000-0000-0000000002',
+        'aliquot_uuid' => '000000-0000-0000-0000-0000000002',
         'source_type' => 'library',
         'source_barcode' => 'PR-rna-00000001_H12',
         'sample_name' => 'aliquot-sample',


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Rename aliquot table's `lims_uuid` column to `aliquot_uuid`

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
