### PR TITLE
Rolling back adding retention instructions to sample table

### DIFF
--- a/db/migrate/20240730074446_add_retention_instruction_column_to_sample_table.rb
+++ b/db/migrate/20240730074446_add_retention_instruction_column_to_sample_table.rb
@@ -1,5 +1,0 @@
-class AddRetentionInstructionColumnToSampleTable < ActiveRecord::Migration[7.0]
-  def change
-    add_column :sample, :retention_instruction, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_30_074446) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_26_144332) do
   create_table "aliquot", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "id_lims", null: false, comment: "The LIMS system that the aliquot was created in"
     t.string "aliquot_uuid", null: false, comment: "The UUID of the aliquot in the LIMS system"
@@ -366,7 +366,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_30_074446) do
     t.string "gc_content"
     t.string "dna_source"
     t.string "priority_level", comment: "Priority level eg Medium, High etc"
-    t.string "retention_instruction"
     t.index ["accession_number"], name: "sample_accession_number_index"
     t.index ["id_sample_lims", "id_lims"], name: "index_sample_on_id_sample_lims_and_id_lims", unique: true
     t.index ["name"], name: "sample_name_index"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -18,7 +18,6 @@ FactoryBot.define do
     id_lims { 'example' }
     sequence(:id_sample_lims)
     last_updated { '2012-03-11 10:22:42' }
-    retention_instruction { 'return_to_customer_after_2_years' }
 
     trait :with_uuid_sample_lims do
       sequence(:uuid_sample_lims) { SecureRandom.uuid }

--- a/spec/models/sample_spec.rb
+++ b/spec/models/sample_spec.rb
@@ -57,8 +57,7 @@ describe Sample do
         'updated_by_manifest' => true,
         'donor_id' => '11111111-2222-3333-4444-555555555556',
         'developmental_stage' => 'Larval: Day 5 ZFS:0000037',
-        'control_type' => 'positive',
-        'retention_instruction' => 'return_to_customer_after_2_years'
+        'control_type' => 'positive'
       }
     end
   end
@@ -75,8 +74,7 @@ describe Sample do
         uuid: '012345-6789-UUID-0001',
         id: 12_345,
         name: 'compound_sample',
-        component_sample_uuids: [{ uuid: component_sample[:uuid_sample_lims] }],
-        retention_instruction: 'return_to_customer_after_2_years'
+        component_sample_uuids: [{ uuid: component_sample[:uuid_sample_lims] }]
       }
     end
 


### PR DESCRIPTION
Closes #633 

#### Changes proposed in this pull request

- Removing adding the `retention_instruction` column in `sample` table.

This migration has already been applied in UAT warehouse. We can introduce a `remove_column` migration but that will cause problems when the two migrations `add_column` and `remove_column` goes into production as `add_column` in `sample` table is a huge task (as it is ~4Gi in size).

So the suggested change rollbacks the changes done for adding retention instructions to `sample` table, so that it will have no effect on the `sample` table in production. The migration added to UAT database is to be manually removed.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
