### PR TITLE
Y24-317 Update  id_sample_lims column with sample name for samples from Traction

### DIFF
--- a/lib/tasks/update_id_sample_lims.rake
+++ b/lib/tasks/update_id_sample_lims.rake
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Rails task to update the id_sample_lims column based on the name column in samples table for samples
+# Why is this task needed?
+# The id_sample_lims column in the samples table is used to store the ID of the sample in Traction.
+# However, this is clashing with IDs in the sample table in the warehouse, causing problems for NPG.
+# NPG relies on the uniqueness of these IDs as they use Sequencescape IDs.
+# To resolve this issue, we need to update the id_sample_lims column to the value of the name column for samples where id_lims is "Traction".
+namespace :sample_table do
+  # This rake task updates the id_sample_lims column to the value of the name column
+  # for samples where id_lims is "Traction". If the name is already present in the
+  # id_sample_lims column, the sample will be skipped.
+  #
+  # Usage: bundle exec rake sample_table:update_id_sample_lims
+  #
+  # The task performs the following steps:
+  # 1. Fetch all samples where id_lims is "Traction".
+  # 2. For each sample, check if the name is already present in the id_sample_lims column.
+  # 3. If the name is not present, update the id_sample_lims column to the value of the name column.
+  # 4. Skip the sample if the name is already present in the id_sample_lims column.
+  #
+  desc 'Update id_sample_lims column to the value of the name column if id_lims is "Traction"'
+
+  task update_id_sample_lims: :environment do
+    Sample.where(id_lims: 'Traction').find_each do |sample|
+      # Skip updating the sample if the id_sample_lims already contains the sample's name
+      next if Sample.exists?(id_sample_lims: sample.name)
+
+      puts "Updating id_sample_lims for sample #{sample.id} to #{sample.name}"
+      sample.id_sample_lims = sample.name
+
+      begin
+        sample.save!
+      rescue ActiveRecord::ActiveRecordError, StandardError => e
+        puts "Failed to update id_sample_lims for sample #{sample.id}: #{e.message}"
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/update_id_sample_lims.rake_spec.rb
+++ b/spec/lib/tasks/update_id_sample_lims.rake_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rake'
+# only load Rake tasks if they haven't been loaded already
+Rails.application.load_tasks if Rake::Task.tasks.empty?
+
+RSpec.describe 'RakeTasks' do
+  describe 'sample_table:update_id_sample_lims' do
+    let!(:traction_sample) { create(:sample, id_lims: 'Traction', name: 'SampleName1', id_sample_lims: 'OldValue1', uuid_sample_lims: SecureRandom.uuid) }
+    let!(:non_traction_sample) { create(:sample, id_lims: 'Other', name: 'SampleName2', id_sample_lims: 'OldValue2', uuid_sample_lims: SecureRandom.uuid) }
+    let!(:existing_sample) { create(:sample, id_lims: 'Traction', name: 'SampleName1', id_sample_lims: 'OldValue2', uuid_sample_lims: SecureRandom.uuid) }
+
+    it 'updates id_sample_lims to the value of the name column for traction samples' do
+      expect { Rake::Task['sample_table:update_id_sample_lims'].invoke }.to change { traction_sample.reload.id_sample_lims }.from('OldValue1').to('SampleName1').and output(
+        /Updating id_sample_lims for sample #{traction_sample.id} to SampleName1/
+      ).to_stdout
+    end
+
+    it 'does not change id_sample_lims for non-traction samples' do
+      expect { Rake::Task['sample_table:update_id_sample_lims'].invoke }.not_to(change { non_traction_sample.reload.id_sample_lims })
+    end
+
+    it 'does not change id_sample_lims if the name is already in id_sample_lims' do
+      expect { Rake::Task['sample_table:update_id_sample_lims'].invoke }.not_to(change { existing_sample.reload.id_sample_lims })
+    end
+    it 'raises an error if saving the sample fails' do
+      allow_any_instance_of(Sample).to receive(:save!).and_raise(ActiveRecord::ActiveRecordError, 'Simulated save error')
+
+      expect do
+        Rake::Task['sample_table:update_id_sample_lims'].invoke
+      end.to output(/Failed to update id_sample_lims for sample #{traction_sample.id}: Simulated save error/).to_stdout
+    end
+  end
+end

--- a/spec/lib/tasks/update_id_sample_lims.rake_spec.rb
+++ b/spec/lib/tasks/update_id_sample_lims.rake_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe 'RakeTasks' do
     let!(:non_traction_sample) { create(:sample, id_lims: 'Other', name: 'SampleName2', id_sample_lims: 'OldValue2', uuid_sample_lims: SecureRandom.uuid) }
     let!(:existing_sample) { create(:sample, id_lims: 'Traction', name: 'SampleName1', id_sample_lims: 'OldValue2', uuid_sample_lims: SecureRandom.uuid) }
 
+    before do
+      Rake::Task['sample_table:update_id_sample_lims'].reenable
+    end
+
     it 'updates id_sample_lims to the value of the name column for traction samples' do
       expect { Rake::Task['sample_table:update_id_sample_lims'].invoke }.to change { traction_sample.reload.id_sample_lims }.from('OldValue1').to('SampleName1').and output(
         /Updating id_sample_lims for sample #{traction_sample.id} to SampleName1/


### PR DESCRIPTION
Closes https://github.com/sanger/unified_warehouse/issues/676

#### Changes proposed in this pull request

- Add a rake task to update the id_sample_lims column values from sample ID to sample name in the samples table for samples from Traction.
 ` bundle exec rake sample_table:update_id_sample_lims`

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
