### PR TITLE
Y25-422-2 - Ultima updates

### DIFF
--- a/app/models/useq_wafer.rb
+++ b/app/models/useq_wafer.rb
@@ -14,7 +14,7 @@ class UseqWafer < ApplicationRecord
   # NOTE: The actual wafers have identifiers etched onto them, but we do not track them
   # and we do not want to confuse them with the LIMs-specific identifiers.
   def self.base_resource_key
-    'id_wafer_lims'
+    'batch_for_opentrons'
   end
 
   has_associated(:study)  # association using id_study_tmp foreign key
@@ -23,8 +23,8 @@ class UseqWafer < ApplicationRecord
   # We expand the wafer message into multiple rows. The following keys are
   # used to identify the rows.
   has_composition_keys(
-    :id_wafer_lims,
-    :lane,
+    :batch_for_opentrons,
+    :request_order,
     :tag_sequence
   )
 
@@ -36,6 +36,6 @@ class UseqWafer < ApplicationRecord
 
     ignore(:lanes) # This key is for the nested section; not mapped to a column.
 
-    translate(wafer_id: :id_wafer_lims)
+    translate(wafer_id: :batch_for_opentrons)
   end
 end

--- a/db/migrate/20251023142000_add_ultima_seq_wafer_table.rb
+++ b/db/migrate/20251023142000_add_ultima_seq_wafer_table.rb
@@ -3,15 +3,17 @@
 # Migration to add the 'useq_wafer' table to store Ultima Genomics instrument's wafer information
 class AddUltimaSeqWaferTable < ActiveRecord::Migration[7.2]
   def change
-    create_table :useq_wafer, primary_key: :id_useq_wafer_tmp do |t|
+    create_table :useq_wafer, id: false, options: 'CHARSET=utf8 COLLATE=utf8_unicode_ci' do |t|
       # Columns required for NPG linkage and basic tracking
+      t.column "id_useq_wafer_tmp", "integer unsigned auto_increment", primary_key: true, comment: "Internal to this database, id value can change"
       t.datetime "last_updated", precision: nil, null: false, comment: "Timestamp of last update"
       t.datetime "recorded_at", precision: nil, null: false, comment: "Timestamp of warehouse update"
       t.integer "id_sample_tmp", null: false, comment: "Sample id, see \"sample.id_sample_tmp\"", unsigned: true
       t.integer "id_study_tmp", null: false, comment: "Study id, see \"study.id_study_tmp\"", unsigned: true
-      t.string "id_wafer_lims", limit: 20, null: false, comment: "LIMs-specific wafer id, batch_id for Sequencescape"
+      t.string "id_wafer_lims", limit: 60, null: false, comment: "LIMs-specific wafer id, a concatenation of batch_for_opentrons, id_pool_lims and request_order"
+      t.string "batch_for_opentrons", limit: 20, null: false, comment: "LIMs-specific identifier, batch_id for Sequencescape"
       t.string "id_lims", limit: 10, null: false, comment: "LIM system identifier, e.g. CLARITY-GCLP, SEQSCAPE", index: true
-      t.integer "lane", limit: 2, null: false, comment: "Wafer lane number", unsigned: true
+      t.integer "request_order", limit: 2, null: false, comment: "LIMs-specific identifier for order in a batch", unsigned: true
       t.string "entity_type", limit: 30, null: false, comment: "Lane type: library, library_indexed"
       t.string "tag_sequence", limit: 30, comment: "Tag sequence"
       t.string "pipeline_id_lims", limit: 60, comment: "LIMs-specific pipeline identifier that unambiguously defines library type"
@@ -46,8 +48,8 @@ class AddUltimaSeqWaferTable < ActiveRecord::Migration[7.2]
     add_foreign_key :useq_wafer, :sample, column: :id_sample_tmp, primary_key: :id_sample_tmp, name: "useq_wafer_sample_fk"
     add_foreign_key :useq_wafer, :study, column: :id_study_tmp, primary_key: :id_study_tmp, name: "useq_wafer_study_fk"
     add_index :useq_wafer, %i[
-      id_wafer_lims
-      lane
+      batch_for_opentrons
+      request_order
       tag_sequence
       id_lims
     ], unique: true, name: 'index_useq_wafer_on_composition_keys'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -524,14 +524,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_23_142000) do
     t.index ["id_study_tmp"], name: "study_users_study_fk"
   end
 
-  create_table "useq_wafer", primary_key: "id_useq_wafer_tmp", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "useq_wafer", primary_key: "id_useq_wafer_tmp", id: { type: :integer, comment: "Internal to this database, id value can change", unsigned: true }, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "last_updated", precision: nil, null: false, comment: "Timestamp of last update"
     t.datetime "recorded_at", precision: nil, null: false, comment: "Timestamp of warehouse update"
     t.integer "id_sample_tmp", null: false, comment: "Sample id, see \"sample.id_sample_tmp\"", unsigned: true
     t.integer "id_study_tmp", null: false, comment: "Study id, see \"study.id_study_tmp\"", unsigned: true
-    t.string "id_wafer_lims", limit: 20, null: false, comment: "LIMs-specific wafer id, batch_id for Sequencescape"
+    t.string "id_wafer_lims", limit: 60, null: false, comment: "LIMs-specific wafer id, a concatenation of batch_for_opentrons, id_pool_lims and request_order"
+    t.string "batch_for_opentrons", limit: 20, null: false, comment: "LIMs-specific identifier, batch_id for Sequencescape"
     t.string "id_lims", limit: 10, null: false, comment: "LIM system identifier, e.g. CLARITY-GCLP, SEQSCAPE"
-    t.integer "lane", limit: 2, null: false, comment: "Wafer lane number", unsigned: true
+    t.integer "request_order", limit: 2, null: false, comment: "LIMs-specific identifier for order in a batch", unsigned: true
     t.string "entity_type", limit: 30, null: false, comment: "Lane type: library, library_indexed"
     t.string "tag_sequence", limit: 30, comment: "Tag sequence"
     t.string "pipeline_id_lims", limit: 60, comment: "LIMs-specific pipeline identifier that unambiguously defines library type"
@@ -555,12 +556,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_23_142000) do
     t.string "otr_instrument_name", comment: "Opentron instrument name"
     t.string "amp_assign_control_bead_tube", comment: "AMP assign control bead tube barcode"
     t.string "amp_instrument_name", comment: "AMP instrument name"
+    t.index ["batch_for_opentrons", "request_order", "tag_sequence", "id_lims"], name: "index_useq_wafer_on_composition_keys", unique: true
     t.index ["id_library_lims"], name: "index_useq_wafer_on_id_library_lims"
     t.index ["id_lims"], name: "index_useq_wafer_on_id_lims"
     t.index ["id_pool_lims"], name: "index_useq_wafer_on_id_pool_lims"
     t.index ["id_sample_tmp"], name: "useq_wafer_sample_fk"
     t.index ["id_study_tmp"], name: "useq_wafer_study_fk"
-    t.index ["id_wafer_lims", "lane", "tag_sequence", "id_lims"], name: "index_useq_wafer_on_composition_keys", unique: true
   end
 
   add_foreign_key "bmap_flowcell", "sample", column: "id_sample_tmp", primary_key: "id_sample_tmp", name: "fk_bmap_flowcell_to_sample"

--- a/spec/models/useq_wafer_spec.rb
+++ b/spec/models/useq_wafer_spec.rb
@@ -8,7 +8,7 @@ describe UseqWafer do
 
   shared_examples_for 'a wafer' do
     it_behaves_like 'maps JSON fields', {
-      wafer_id: :id_wafer_lims
+      wafer_id: :batch_for_opentrons
     }
 
     it_behaves_like 'belongs to', %i[study sample], { lanes: :samples }
@@ -84,7 +84,7 @@ describe UseqWafer do
 
   context 'a message with clashing samples' do
     let(:expected_identifiers) do
-      'id_wafer_lims, lane, tag_sequence'
+      'batch_for_opentrons, request_order, tag_sequence'
     end
     let(:example_lims) { 'example' }
 

--- a/spec/support/shared_json_examples.rb
+++ b/spec/support/shared_json_examples.rb
@@ -215,7 +215,8 @@ shared_examples 'large useq wafer json' do
       'updated_at' => '2012-03-11 10:22:42',
       'lanes' => [
         {
-          'lane' => 1,
+          'request_order' => 1,
+          'id_wafer_lims' => '1123_NT1234567X_1',
           'id_pool_lims' => 'NT1234567X',
           'otr_instrument_name' => 'otr_inst_1',
           'amp_instrument_name' => 'amp_inst_1',
@@ -260,7 +261,8 @@ shared_examples 'small useq wafer json' do
       'updated_at' => '2012-03-11 10:22:42',
       'lanes' => [
         {
-          'lane' => 1,
+          'request_order' => 1,
+          'id_wafer_lims' => '1123_NT1234567X_1',
           'id_pool_lims' => 'NT1234567X',
           'otr_instrument_name' => 'otr_inst_1',
           'amp_instrument_name' => 'amp_inst_1',


### PR DESCRIPTION
Relates to https://github.com/sanger/unified_warehouse/issues/840

SS PR: https://github.com/sanger/sequencescape/pull/5372

updates useq_wafer creation migration to reflect requested UAT changes

- Moves batch id identifer to new column batch_for_opentrons
- Adds request_order column for identifying tubes in a batch
- Removes lane column
- Explicity sets charset to utf8
- Adds comment and changes type of id_useq_wafer_tmp
- Changes id_wafer_lims to hold a unique identifer string matching sample sheet name

### UAT plan

To save us having to do an in place migration I am planning to rollback the previous migration (useq_wafer table creation) on uat - dropping existing data. I have confirmed this is ok with NPG.
Then deploy new version of migration (current pr) and run migrations.
