### PR TITLE
feat(useq-wafer): updates entity column comments to be more relevant …

### DIFF
--- a/db/migrate/20251023142000_add_ultima_seq_wafer_table.rb
+++ b/db/migrate/20251023142000_add_ultima_seq_wafer_table.rb
@@ -14,7 +14,7 @@ class AddUltimaSeqWaferTable < ActiveRecord::Migration[7.2]
       t.string "batch_for_opentrons", limit: 20, null: false, comment: "LIMs-specific identifier, batch_id for Sequencescape"
       t.string "id_lims", limit: 10, null: false, comment: "LIM system identifier, e.g. CLARITY-GCLP, SEQSCAPE", index: true
       t.integer "request_order", limit: 2, null: false, comment: "LIMs-specific identifier for order in a batch", unsigned: true
-      t.string "entity_type", limit: 30, null: false, comment: "Lane type: library, library_indexed"
+      t.string "entity_type", limit: 30, null: false, comment: "Entity type, e.g. library_indexed or in the future some other library type"
       t.string "tag_sequence", limit: 30, comment: "Tag sequence"
       t.string "pipeline_id_lims", limit: 60, comment: "LIMs-specific pipeline identifier that unambiguously defines library type"
       t.string "bait_name", limit: 50, comment: "WTSI-wide name that uniquely identifies a bait set"
@@ -24,7 +24,7 @@ class AddUltimaSeqWaferTable < ActiveRecord::Migration[7.2]
       t.string "primer_panel", comment: "Primer Panel name"
       t.string "id_pool_lims", limit: 20, null: false, comment: "Most specific LIMs identifier associated with the pool", index: true
       t.string "id_library_lims", comment: "Earliest LIMs identifier associated with library creation", index: true
-      t.string "entity_id_lims", limit: 20, null: false, comment: "Most specific LIMs identifier associated with this lane or plex or spike"
+      t.string "entity_id_lims", limit: 20, null: false, comment: "Most specific LIMs identifier associated with this library"
 
       # Columns required for lot number tracking
       t.string "otr_carrier_lot_number", comment: "Opentron carrier lot number"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -533,7 +533,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_23_142000) do
     t.string "batch_for_opentrons", limit: 20, null: false, comment: "LIMs-specific identifier, batch_id for Sequencescape"
     t.string "id_lims", limit: 10, null: false, comment: "LIM system identifier, e.g. CLARITY-GCLP, SEQSCAPE"
     t.integer "request_order", limit: 2, null: false, comment: "LIMs-specific identifier for order in a batch", unsigned: true
-    t.string "entity_type", limit: 30, null: false, comment: "Lane type: library, library_indexed"
+    t.string "entity_type", limit: 30, null: false, comment: "Entity type, e.g. library_indexed or in the future some other library type"
     t.string "tag_sequence", limit: 30, comment: "Tag sequence"
     t.string "pipeline_id_lims", limit: 60, comment: "LIMs-specific pipeline identifier that unambiguously defines library type"
     t.string "bait_name", limit: 50, comment: "WTSI-wide name that uniquely identifies a bait set"
@@ -543,7 +543,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_23_142000) do
     t.string "primer_panel", comment: "Primer Panel name"
     t.string "id_pool_lims", limit: 20, null: false, comment: "Most specific LIMs identifier associated with the pool"
     t.string "id_library_lims", comment: "Earliest LIMs identifier associated with library creation"
-    t.string "entity_id_lims", limit: 20, null: false, comment: "Most specific LIMs identifier associated with this lane or plex or spike"
+    t.string "entity_id_lims", limit: 20, null: false, comment: "Most specific LIMs identifier associated with this library"
     t.string "otr_carrier_lot_number", comment: "Opentron carrier lot number"
     t.datetime "otr_carrier_expiry", precision: nil, comment: "Opentron carrier expiry date"
     t.string "otr_reaction_mix_7_lot_number", comment: "Opentron reaction mix 7 lot number"


### PR DESCRIPTION
Updates Useq_wafer column comments to NPG suggestions - see below.

#### Changes proposed in this pull request

- Update entity_type column comment
    - "I doubt we will ever have a non-indexed library. Out of four types we have for Illumina, library, library_control, library_indexed, library_indexed_spike, only library_indexed applies to UG. This column might ve redundant, but it might be prudent to keep it in case we have to expand the range. Suggested comment 'Entity type, eg library_indexed or in future some other library type"
  
- Update entity_id_lims comment
    - "UG seems to have their own internal controls. At the moment we do not not add spiked-in PhiX. Might be better to change the comment to 'Most specific LIMs identifier associated with this library"
