### PR TITLE
Y25-687 - Additional eseq flowcell fields

### DIFF
--- a/app/models/eseq_flowcell.rb
+++ b/app/models/eseq_flowcell.rb
@@ -28,7 +28,7 @@ class EseqFlowcell < ApplicationRecord
     :tag2_sequence
   )
 
-  json do # rubocop:disable Metrics/BlockLength
+  json do
     has_nested_model(:lanes) do # The message has nested lanes section.
       ignore(:samples, :controls) # These keys are not mapped to columns.
 
@@ -38,39 +38,7 @@ class EseqFlowcell < ApplicationRecord
 
     ignore(:lanes) # This key is for the nested section; not mapped to a column.
 
-    # The following fields are included in the Iseq flowcell mesage. We assume
-    # the same message for Eseq flowcell as well until the Sequencescape side of
-    # the messaging is implemented. However, we need to ignore the fields that
-    # are not mapped to the columns of the eseq_flowcell table.
-    ignore(
-      :manual_qc,
-      :priority,
-      :external_release,
-      :purpose,
-      :spiked_phix_barcode,
-      :spiked_phix_percentage,
-      :workflow,
-      :loading_concentration,
-      :flowcell_barcode,
-      :forward_read_length,
-      :reverse_read_length,
-      :tag_set_id_lims,
-      :tag_set_name,
-      :tag_identifier,
-      :tag2_set_id_lims,
-      :tag2_set_name,
-      :tag2_identifier,
-      :cost_code,
-      :is_r_and_d,
-      :tag_index,
-      :team,
-      :suboptimal,
-      :legacy_library_id
-    )
     # We translate the fields from the message to the columns of the table.
-    # Note that the 'position' column of the iseq_flowcell table is named as
-    # 'lane' in the eseq_flowcell table. If the mapping is done on the
-    # Sequencescape side, we need to update the translation accordingly.
-    translate(flowcell_id: :id_flowcell_lims, position: :lane)
+    translate(flowcell_id: :id_flowcell_lims)
   end
 end

--- a/db/migrate/20260407081702_add_eseq_flowcell_columns.rb
+++ b/db/migrate/20260407081702_add_eseq_flowcell_columns.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddEseqFlowcellColumns < ActiveRecord::Migration[7.2]
+  def change
+    add_column :eseq_flowcell, :quant_method_used, :string, limit: 255, comment: 'Quantification method used for the run'
+    add_column :eseq_flowcell, :custom_primer_kit_used, :string, limit: 255, comment: 'Custom primer kit used for the run, values: Yes, No'
+  end
+end

--- a/db/migrate/20260407081702_add_eseq_flowcell_columns.rb
+++ b/db/migrate/20260407081702_add_eseq_flowcell_columns.rb
@@ -2,7 +2,7 @@
 
 class AddEseqFlowcellColumns < ActiveRecord::Migration[7.2]
   def change
-    add_column :eseq_flowcell, :quant_method_used, :string, limit: 255, comment: 'Quantification method used for the run'
-    add_column :eseq_flowcell, :custom_primer_kit_used, :string, limit: 255, comment: 'Custom primer kit used for the run, values: Yes, No'
+    add_column :eseq_flowcell, :quant_method_used, :string, limit: 50, comment: 'Quantification method used for the run'
+    add_column :eseq_flowcell, :custom_primer_kit_used, :string, limit: 10, comment: 'Has a custom primer kit been used for the run: Yes, No'
   end
 end

--- a/db/migrate/20260407081702_add_eseq_flowcell_columns.rb
+++ b/db/migrate/20260407081702_add_eseq_flowcell_columns.rb
@@ -3,6 +3,6 @@
 class AddEseqFlowcellColumns < ActiveRecord::Migration[7.2]
   def change
     add_column :eseq_flowcell, :quant_method_used, :string, limit: 50, comment: 'Quantification method used for the run'
-    add_column :eseq_flowcell, :custom_primer_kit_used, :string, limit: 10, comment: 'Has a custom primer kit been used for the run: Yes, No'
+    add_column :eseq_flowcell, :custom_primer_kit_used, :boolean, comment: 'Whether a custom primer kit been used for the run: 1 (yes), 0 (no)'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,8 +78,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_07_081702) do
     t.string "id_library_lims", comment: "Earliest LIMs identifier associated with library creation"
     t.string "primer_panel", comment: "Primer Panel name"
     t.string "entity_id_lims", limit: 20, null: false, comment: "Most specific LIMs identifier associated with this lane or plex or spike"
-    t.string "quant_method_used", comment: "Quantification method used for the run"
-    t.string "custom_primer_kit_used", comment: "Custom primer kit used for the run, values: Yes, No"
+    t.string "quant_method_used", limit: 50, comment: "Quantification method used for the run"
+    t.string "custom_primer_kit_used", limit: 10, comment: "Has a custom primer kit been used for the run: Yes, No"
     t.index ["id_flowcell_lims", "lane", "tag_sequence", "tag2_sequence", "id_lims"], name: "index_eseq_flowcell_on_composition_keys", unique: true
     t.index ["id_library_lims"], name: "index_eseq_flowcell_on_id_library_lims"
     t.index ["id_pool_lims"], name: "index_eseq_flowcell_on_id_pool_lims"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,7 +79,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_07_081702) do
     t.string "primer_panel", comment: "Primer Panel name"
     t.string "entity_id_lims", limit: 20, null: false, comment: "Most specific LIMs identifier associated with this lane or plex or spike"
     t.string "quant_method_used", limit: 50, comment: "Quantification method used for the run"
-    t.string "custom_primer_kit_used", limit: 10, comment: "Has a custom primer kit been used for the run: Yes, No"
+    t.boolean "custom_primer_kit_used", comment: "Whether a custom primer kit been used for the run: 1 (yes), 0 (no)"
     t.index ["id_flowcell_lims", "lane", "tag_sequence", "tag2_sequence", "id_lims"], name: "index_eseq_flowcell_on_composition_keys", unique: true
     t.index ["id_library_lims"], name: "index_eseq_flowcell_on_id_library_lims"
     t.index ["id_pool_lims"], name: "index_eseq_flowcell_on_id_pool_lims"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_23_142000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_07_081702) do
   create_table "aliquot", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "id_lims", null: false, comment: "The LIMS system that the aliquot was created in"
     t.string "aliquot_uuid", null: false, comment: "The UUID of the aliquot in the LIMS system"
@@ -78,6 +78,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_23_142000) do
     t.string "id_library_lims", comment: "Earliest LIMs identifier associated with library creation"
     t.string "primer_panel", comment: "Primer Panel name"
     t.string "entity_id_lims", limit: 20, null: false, comment: "Most specific LIMs identifier associated with this lane or plex or spike"
+    t.string "quant_method_used", comment: "Quantification method used for the run"
+    t.string "custom_primer_kit_used", comment: "Custom primer kit used for the run, values: Yes, No"
     t.index ["id_flowcell_lims", "lane", "tag_sequence", "tag2_sequence", "id_lims"], name: "index_eseq_flowcell_on_composition_keys", unique: true
     t.index ["id_library_lims"], name: "index_eseq_flowcell_on_id_library_lims"
     t.index ["id_pool_lims"], name: "index_eseq_flowcell_on_id_pool_lims"

--- a/spec/models/eseq_flowcell_spec.rb
+++ b/spec/models/eseq_flowcell_spec.rb
@@ -8,36 +8,8 @@ describe EseqFlowcell do
 
   shared_examples_for 'a flowcell' do
     it_behaves_like 'maps JSON fields', {
-      flowcell_id: :id_flowcell_lims, position: :lane
+      flowcell_id: :id_flowcell_lims
     }
-
-    # Eseq flowcell has fewer fields than Iseq flowcell and ignores the fields
-    # that are not mapped to the columns of the eseq_flowcell table.
-    it_behaves_like 'ignores JSON fields', %w[
-      manual_qc
-      priority
-      external_release
-      purpose
-      spiked_phix_barcode
-      spiked_phix_percentage
-      workflow
-      loading_concentration
-      flowcell_barcode
-      forward_read_length
-      reverse_read_length
-      tag_set_id_lims
-      tag_set_name
-      tag_identifier
-      tag2_set_id_lims
-      tag2_set_name
-      tag2_identifier
-      cost_code
-      is_r_and_d
-      tag_index
-      team
-      suboptimal
-      legacy_library_id
-    ]
 
     it_behaves_like 'belongs to', %i[study sample], { lanes: :samples }
 

--- a/spec/support/shared_json_examples.rb
+++ b/spec/support/shared_json_examples.rb
@@ -104,65 +104,39 @@ end
 shared_examples 'large eseq flowcell json' do
   let(:json) do
     {
-
-      'flowcell_barcode' => '12345678903',
       'flowcell_id' => 1123,
-      'forward_read_length' => 222,
-      'reverse_read_length' => 222,
       'updated_at' => '2012-03-11 10:22:42',
-
+      'custom_primer_kit_used' => 'Yes',
+      'quant_method_used' => 'Tapestation',
       'lanes' => [
         {
-          'manual_qc' => false,
-          'position' => 1,
-          'priority' => 1,
+          'lane' => 1,
           'id_pool_lims' => 'NT1234567X',
-          'external_release' => true,
-          'purpose' => 'standard',
-          'spiked_phix_barcode' => 'NT12345Q',
-          'spiked_phix_percentage' => '30',
-          'workflow' => 'Standard',
-          'loading_concentration' => '20',
-
+          'quant_method_used' => 'Tapestation',
+          'custom_primer_kit_used' => 'Yes',
           'samples' => [
             {
-              'tag_index' => 3,
               'tag_sequence' => 'ATAG',
-              'tag_set_id_lims' => '2',
-              'tag_set_name' => 'Sanger_168tags - 10 mer tags',
-              'tag_identifier' => 1,
               'tag2_sequence' => 'GGGG',
-              'tag2_set_id_lims' => '1',
-              'tag2_set_name' => 'Tag 2 Set 1',
-              'tag2_identifier' => 1,
               'pipeline_id_lims' => 'Agilent Pulldown',
               'entity_type' => 'library_indexed',
-              'bait_name' => 'DDD_V5_plus',
               'requested_insert_size_from' => 100,
               'requested_insert_size_to' => 200,
               'sample_uuid' => '000000-0000-0000-0000-0000000000',
               'study_uuid' => '000000-0000-0000-0000-0000000001',
-              'cost_code' => '12345',
-              'entity_id_lims' => 12_345,
-              'is_r_and_d' => false,
               'primer_panel' => 'PrimerPanel1',
               'id_library_lims' => 'SQPP-1234-X:A1',
-              'team' => 'Team A',
-              'suboptimal' => 0,
-              'legacy_library_id' => '12345'
+              'entity_id_lims' => 12_345
             }
           ],
           'controls' => [
             {
               'sample_uuid' => '000000-0000-0000-0000-0000000000',
               'study_uuid' => '000000-0000-0000-0000-0000000001',
-              'tag_index' => 168,
               'entity_type' => 'library_indexed_spike',
               'tag_sequence' => 'TAGA',
-              'tag_set_id_lims' => '2',
-              'entity_id_lims' => '12345',
-              'tag_set_name' => 'Sanger_168tags - 10 mer tags',
-              'id_library_lims' => 'NT1234567C'
+              'id_library_lims' => 'NT1234567C',
+              'entity_id_lims' => 12_345
             }
           ]
         }
@@ -178,12 +152,10 @@ shared_examples 'small eseq flowcell json' do
     {
       'flowcell_id' => 1123,
       'updated_at' => '2012-03-11 10:22:42',
-
       'lanes' => [
         {
-          'position' => 1,
+          'lane' => 1,
           'id_pool_lims' => 'NT1234567X',
-
           'samples' => [
             {
               'tag_sequence' => 'ATAG',


### PR DESCRIPTION
Relates to: https://github.com/sanger/sequencescape/issues/5361
SS PR: https://github.com/sanger/sequencescape/pull/5657

#### Changes proposed in this pull request

- Adds custom_primer_kit_used and quant_method_used fields to eseq_flowcell table
- Cleans up eseq_flowcell message handler now using dedicated message from sequencescape.
