### PR TITLE
Y26-121 - Update mysql to 8.4

### DIFF
--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -19,9 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LOCALHOST: 127.0.0.1 # If we use localhost, rails tries to use a socket
+    strategy:
+      fail-fast: false
+      matrix:
+        mysql-version: ["8.0", "8.4"]
     services:
       mysql:
-        image: mysql:8.0
+        image: mysql:${{ matrix.mysql-version }}
         ports:
           - 3306:3306
         env:

--- a/.github/workflows/ruby_ci.yml
+++ b/.github/workflows/ruby_ci.yml
@@ -21,13 +21,17 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DBHOST: 127.0.0.1 # If we use localhost, rails tries to use a socket
+    strategy:
+      fail-fast: false
+      matrix:
+        mysql-version: ["8.0", "8.4"]
 
     # Services
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idservices
     services:
       mysql:
         # Use the Mysql docker image https://hub.docker.com/_/mysql
-        image: mysql:8.0
+        image: mysql:${{ matrix.mysql-version }}
         ports:
           - 3306:3306 # Default port mappings
           # Monitor the health of the container to mesaure when it is ready

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ If the message above is consumed by `unified_warehouse`, it will create a new re
 
 ### Requirement
 
-1. MySQL (currently 8.0) is required and usually installed with homebrew:
+1. MySQL (currently 8.4) is required and usually installed with homebrew:
 
-       brew install mysql@8.0
-       brew link mysql@8.0 --force
+       brew install mysql@8.4
+       brew link mysql@8.4 --force
 
 ### Installation
 


### PR DESCRIPTION
Closes #889 

#### Changes proposed in this pull request

- Adds matrix to ci to run tests on both 8.0 and 8.4 while both are supported.
- Updates docs to reference mysql 8.4

