### PR TITLE
Y26-189 - [PR] [BUG] fix stock resource composition matching

### DIFF
--- a/app/models/stock_resource.rb
+++ b/app/models/stock_resource.rb
@@ -18,6 +18,118 @@ class StockResource < ApplicationRecord
 
     has_nested_model(:samples)
 
-    ignore(:samples)
+    # Ignore nested container key and all internal *_tmp ids from payloads.
+    # Internal FKs are derived from UUID lookups, not trusted from messages.
+    ignore(
+      :samples,
+      :id_stock_resource_tmp,
+      :id_sample_tmp,
+      :id_study_tmp
+    )
   end
+
+  # Resolve sample UUID before composition key matching.
+  #
+  # Overrides the parent {CompositeResourceTools#create_or_update} method
+  # to resolve incoming +sample_uuid+ values to their database
+  # +id_sample_tmp+ foreign keys before composition key matching occurs.
+  # This is necessary because +id_sample_tmp+ is not part of the incoming
+  # message but is part of the composition key
+  # (+[:id_stock_resource_lims, :id_sample_tmp]+). Without this
+  # pre-resolution, update operations would fail to match existing records
+  # and would recreate rows instead of updating them in place.
+  #
+  # The resolution is applied to each attribute object (each sample entry)
+  # before the parent's composition matching logic runs, ensuring that
+  # composition keys have real values on both incoming and persisted records.
+  #
+  # @param [Array<Hashie::Mash>, Hashie::Mash] attributes One or more
+  #   attribute objects (typically expanded from nested model samples).
+  #   Each object is expected to have a +sample_uuid+ field that maps to
+  #   an existing {Sample} record.
+  #
+  # @return [true] Always returns +true+ on success (following parent
+  #   method contract). Returns early with +true+ if attributes array is
+  #   empty.
+  #
+  # @raise [ActiveRecord::RecordNotFound] If a +sample_uuid+ does not
+  #   resolve to an existing {Sample} record. This exception is intended
+  #   for Warren consumer delay handling (transient failures).
+  #
+  # @example Single sample entry update
+  #   attributes = [
+  #     {
+  #       id_stock_resource_lims: "12345",
+  #       sample_uuid: "550e8400-e29b-41d4-a716-446655440000",
+  #       study_uuid: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+  #       current_volume: 5.5
+  #     }
+  #   ]
+  #   StockResource.create_or_update(attributes)
+  #   # => true (id_sample_tmp is resolved and populated before matching)
+  #
+  # @example Multiple sample entries (nested model expansion)
+  #   attributes = [
+  #     {
+  #       id_stock_resource_lims: "12345",
+  #       sample_uuid: "uuid-1",
+  #       study_uuid: "study-1"
+  #     },
+  #     {
+  #       id_stock_resource_lims: "12345",
+  #       sample_uuid: "uuid-2",
+  #       study_uuid: "study-2"
+  #     }
+  #   ]
+  #   StockResource.create_or_update(attributes)
+  #   # => true (each entry has its sample UUID resolved independently)
+  #
+  # @note The parent {CompositeResourceTools#create_or_update} method will
+  #   still invoke {CompositeResourceTools#has_associated
+  #   has_associated(:sample)} callbacks during validation, which will
+  #   re-verify and update the FK. This pre-resolution is purely for
+  #   composition key matching correctness.
+  #
+  # @see CompositeResourceTools#create_or_update
+  # @see CompositeResourceTools#composite_key_for
+  def self.create_or_update(attributes)
+    attributes = Array.convert(attributes)
+    return true if attributes.empty?
+
+    attributes.each do |attr|
+      resolve_sample_association(attr) if attr.sample_uuid.present?
+    end
+
+    super
+  end
+
+  # Resolve a sample UUID to its database foreign key ID.
+  #
+  # Looks up the {Sample} record matching the given UUID and populates the
+  # attribute object's +id_sample_tmp+ field with the database-assigned value.
+  # This field is used as part of the composition key but is ignored during
+  # JSON parsing, so it must be restored before composition key matching.
+  #
+  # @param [Hashie::Mash] attr The attribute object (typically from expanding
+  #   nested model samples). Must have a +sample_uuid+ field.
+  #
+  # @return [void] Mutates +attr+ in place by setting +id_sample_tmp+.
+  #
+  # @raise [ActiveRecord::RecordNotFound] If no {Sample} exists with the
+  #   provided +sample_uuid+.
+  #
+  # @example
+  #   attr = { sample_uuid: "550e8400-e29b-41d4-a716-446655440000" }
+  #   resolve_sample_association(attr)
+  #   attr.id_sample_tmp  # => 1096 (database value for that sample)
+  #
+  # @see Sample.with_uuid
+  def self.resolve_sample_association(attr)
+    sample = Sample.with_uuid(attr.sample_uuid).first
+    raise ActiveRecord::RecordNotFound, "No sample with uuid '#{attr.sample_uuid}'" if sample.nil?
+
+    attr.id_sample_tmp = sample.id_sample_tmp
+  end
+
+  private_class_method :resolve_sample_association
 end

--- a/spec/models/stock_resource_spec.rb
+++ b/spec/models/stock_resource_spec.rb
@@ -68,9 +68,10 @@ describe StockResource do
       let(:example_lims) { 'example' }
 
       let(:updated_json) do
-        updated_json = json.dup
+        updated_json = json.deep_dup
         updated_json['current_volume'] = 1.00
-        updated_json['updated_at'] = '2012-03-11 10:22:42'
+        # Use a later timestamp so update-in-place logic actually works.
+        updated_json['updated_at'] = '2012-03-11 10:22:43'
         updated_json
       end
 
@@ -80,6 +81,7 @@ describe StockResource do
         described_class.create_or_update_from_json(updated_json, example_lims)
         new_ids = described_class.pluck(:id_stock_resource_tmp, :id_sample_tmp)
         expect(new_ids).to eq(original_ids)
+        expect(described_class.last.current_volume).to eq(1.00)
       end
     end
   end
@@ -122,6 +124,136 @@ describe StockResource do
         'measured_gender' => 'Unknown'
 
       }
+    end
+
+    context 'when the message contains internal *_tmp ids' do
+      # Incoming internal *_tmp ids must be ignored/stripped from the message.
+      # The record resolves sample/study from sample_uuid/study_uuid and
+      # persists database-derived foreign keys.
+      let(:example_lims) { 'example' }
+      let(:incoming_id_sample_tmp) { mock_sample.id_sample_tmp + 10_000 }
+      let(:incoming_id_study_tmp) { mock_study.id_study_tmp + 10_000 }
+      let(:incoming_id_stock_resource_tmp) { 10_000 }
+
+      let(:json) do
+        {
+          'created_at' => '2012-03-11T10:22:42+00:00',
+          'updated_at' => '2012-03-11T10:22:42+00:00',
+          'samples' => [
+            {
+              'id_stock_resource_tmp' => incoming_id_stock_resource_tmp, # This must be ignored.
+              'id_sample_tmp' => incoming_id_sample_tmp, # This must be ignored.
+              'id_study_tmp' => incoming_id_study_tmp,   # This must be ignored.
+              'sample_uuid' => mock_sample.uuid_sample_lims,
+              'study_uuid' => mock_study.uuid_study_lims
+            }
+          ],
+          'stock_resource_id' => 12_345,
+          'stock_resource_uuid' => '000000-0000-0000-0000-0000000002',
+          'machine_barcode' => '1220456987123',
+          'human_barcode' => 'DN456987D',
+          'labware_coordinate' => 'A1',
+          'labware_type' => 'well'
+        }
+      end
+
+      context 'when creating' do
+        it 'uses the internal ids from the database and ignores the incoming internal ids' do
+          described_class.create_or_update_from_json(json, example_lims)
+
+          stock_resource = described_class.last
+          expect(stock_resource.id_stock_resource_tmp).not_to eq(incoming_id_stock_resource_tmp)
+          expect(stock_resource.id_sample_tmp).to eq(mock_sample.id_sample_tmp)
+          expect(stock_resource.id_sample_tmp).not_to eq(incoming_id_sample_tmp)
+          expect(stock_resource.id_study_tmp).to eq(mock_study.id_study_tmp)
+          expect(stock_resource.id_study_tmp).not_to eq(incoming_id_study_tmp)
+          expect(stock_resource.sample).to eq(mock_sample)
+          expect(stock_resource.study).to eq(mock_study)
+        end
+
+        it 'raises if sample_uuid does not resolve and ignores incoming id_sample_tmp' do
+          # Warren delay path.
+          json['samples'][0]['sample_uuid'] = 'non-existent-sample-uuid'
+
+          expect do
+            described_class.create_or_update_from_json(json, example_lims)
+          end.to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it 'raises if sample_uuid is missing and ignores incoming id_sample_tmp' do
+          # Warren dead-letter path.
+          json['samples'][0].delete('sample_uuid')
+
+          expect do
+            described_class.create_or_update_from_json(json, example_lims)
+          end.to raise_error(ActiveRecord::NotNullViolation)
+        end
+      end
+
+      context 'when updating' do
+        it 'updates record with the internal ids from the database and ignores incoming internal ids' do
+          described_class.create_or_update_from_json(json, example_lims)
+          original_stock_resource = described_class.last
+
+          updated_json = json.deep_dup
+          # The updated_at must be later than the original for the update to occur.
+          updated_json['updated_at'] = (original_stock_resource.last_updated + 1.second).iso8601
+          updated_json['current_volume'] = 5.43
+
+          described_class.create_or_update_from_json(updated_json, example_lims)
+          updated_stock_resource = described_class.last
+
+          expect(described_class.count).to eq(1)
+          expect(updated_stock_resource.id_stock_resource_tmp).to eq(original_stock_resource.id_stock_resource_tmp)
+          expect(updated_stock_resource.id_stock_resource_tmp).not_to eq(incoming_id_stock_resource_tmp)
+          expect(updated_stock_resource.id_stock_resource_lims).to eq(original_stock_resource.id_stock_resource_lims)
+          expect(updated_stock_resource.id_sample_tmp).to eq(mock_sample.id_sample_tmp)
+          expect(updated_stock_resource.id_sample_tmp).not_to eq(incoming_id_sample_tmp)
+          expect(updated_stock_resource.id_study_tmp).to eq(mock_study.id_study_tmp)
+          expect(updated_stock_resource.id_study_tmp).not_to eq(incoming_id_study_tmp)
+          expect(updated_stock_resource.current_volume).to eq(5.43)
+          expect(updated_stock_resource.last_updated).to be > original_stock_resource.last_updated
+        end
+
+        it 'reuses existing records for multiple sample entries and ignores incoming internal ids' do
+          second_sample = create(:sample, :with_uuid_sample_lims)
+          second_study = create(:study, :with_uuid_study_lims)
+
+          multi_sample_json = json.deep_dup
+          multi_sample_json['samples'] = [
+            {
+              'id_stock_resource_tmp' => incoming_id_stock_resource_tmp,
+              'id_sample_tmp' => incoming_id_sample_tmp,
+              'id_study_tmp' => incoming_id_study_tmp,
+              'sample_uuid' => mock_sample.uuid_sample_lims,
+              'study_uuid' => mock_study.uuid_study_lims
+            },
+            {
+              'id_stock_resource_tmp' => incoming_id_stock_resource_tmp + 1,
+              'id_sample_tmp' => second_sample.id_sample_tmp + 10_000,
+              'id_study_tmp' => second_study.id_study_tmp + 10_000,
+              'sample_uuid' => second_sample.uuid_sample_lims,
+              'study_uuid' => second_study.uuid_study_lims
+            }
+          ]
+
+          described_class.create_or_update_from_json(multi_sample_json, example_lims)
+
+          original_rows = described_class.order(:id_sample_tmp).pluck(:id_stock_resource_tmp, :id_sample_tmp)
+          expect(original_rows.length).to eq(2)
+
+          updated_json = multi_sample_json.deep_dup
+          updated_json['updated_at'] = (described_class.last.last_updated + 1.second).iso8601
+          updated_json['current_volume'] = 7.89
+
+          described_class.create_or_update_from_json(updated_json, example_lims)
+
+          updated_rows = described_class.order(:id_sample_tmp).pluck(:id_stock_resource_tmp, :id_sample_tmp)
+          expect(updated_rows).to eq(original_rows)
+          expect(described_class.count).to eq(2)
+          expect(described_class.order(:id_sample_tmp).pluck(:current_volume).uniq).to eq([7.89])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Add internal ids to ignored list to avoid using them from stock_resource message
- Resolve Sample using UUID and find id_sample_tmp to fix composition key comparison
- Update of record will re-use the existing stock_resource row instead of re-creating it
- Fixed existing false positive where actually not tested before
- Added tests for ignoring internal ids, creating, updating, with single and multiple samples

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
