### PR TITLE
Y26-204 - Remove mysql 8.0 from CI matrices

### DIFF
--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mysql-version: ["8.0", "8.4"]
+        mysql-version: ["8.4"]
     services:
       mysql:
         image: mysql:${{ matrix.mysql-version }}

--- a/.github/workflows/ruby_ci.yml
+++ b/.github/workflows/ruby_ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mysql-version: ["8.0", "8.4"]
+        mysql-version: ["8.4"]
 
     # Services
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idservices


### PR DESCRIPTION
Relates to https://github.com/sanger/General-Backlog-Items/issues/738

#### Changes proposed in this pull request

- Removes mysql 8.0 from CI matrices 